### PR TITLE
Remove release pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial-asyncio==0.4
+pyserial-asyncio


### PR DESCRIPTION
`pyserial-asyncio-0.5` was released a while back. Pinning it makes an installation in certain circumstances impossible (e.g., Fedora RPM and `venv` with other tools).

Please make a new release after merging. Thanks in advance.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1907171